### PR TITLE
Expose SNG dynamic-difficulty metadata in bridge diagnostics

### DIFF
--- a/gdextension/src/goguitar_bridge.rs
+++ b/gdextension/src/goguitar_bridge.rs
@@ -39,6 +39,8 @@ pub struct RocksmithBridge {
                              // -1 = unset/invalid, 0 = no capo, >0 = frets already physical/baked.
                              // Fret values are ALWAYS physical — no offset is ever applied.
     sng_tuning:       Vec<i16>, // per-string semitone offsets from standard tuning
+    sng_difficulty_count: i32,  // linked SNG difficulty levels; >1 means dynamic
+    sng_is_dynamic_difficulty: bool,
     /// DDC difficulty band: 0=Easy, 1=Medium, 2=Hard/100% (default).
     /// Set via `set_difficulty(percent)` before calling `load_psarc`.
     difficulty_band:  usize,
@@ -56,6 +58,8 @@ impl IObject for RocksmithBridge {
             sng_difficulty:   -1,
             sng_capo:         0,
             sng_tuning:       vec![],
+            sng_difficulty_count: 1,
+            sng_is_dynamic_difficulty: false,
             difficulty_band:  2,   // default: Hard / 100%
         }
     }
@@ -91,6 +95,12 @@ impl RocksmithBridge {
         self.notes.clear();
         self.wem_data         = None;
         self.preview_wem_data = None;
+        self.sng_start_time = 0.0;
+        self.sng_difficulty = -1;
+        self.sng_capo = 0;
+        self.sng_tuning.clear();
+        self.sng_difficulty_count = 1;
+        self.sng_is_dynamic_difficulty = false;
 
         let path_str = path.to_string();
         godot_print!("RocksmithBridge: loading '{}'", path_str);
@@ -147,7 +157,8 @@ impl RocksmithBridge {
     }
 
     /// Returns a Dictionary with SNG diagnostic fields:
-    ///   `{ "start_time": float, "difficulty": int, "capo": int, "tuning": Array[int] }`
+    ///   `{ "start_time": float, "difficulty": int, "capo": int, "tuning": Array[int],
+    ///      "difficulty_count": int, "is_dynamic_difficulty": bool }`
     /// - `start_time`: when the arrangement begins in the WEM audio (seconds from WEM t=0).
     ///   Note times in `get_notes()` are already absolute from WEM t=0, so no offset
     ///   needs to be applied — this value is purely for diagnostic logging.
@@ -164,6 +175,8 @@ impl RocksmithBridge {
         dict.set(&GString::from("start_time"), self.sng_start_time);
         dict.set(&GString::from("difficulty"),  self.sng_difficulty);
         dict.set(&GString::from("capo"),        self.sng_capo as i32);
+        dict.set(&GString::from("difficulty_count"), self.sng_difficulty_count);
+        dict.set(&GString::from("is_dynamic_difficulty"), self.sng_is_dynamic_difficulty);
         let mut tuning_arr: Array<Variant> = Array::new();
         for &t in &self.sng_tuning {
             tuning_arr.push(&Variant::from(t as i32));
@@ -184,13 +197,17 @@ impl RocksmithBridge {
         self.sng_difficulty = data.sng_difficulty;
         self.sng_capo       = data.sng_capo;
         self.sng_tuning     = data.sng_tuning;   // move — data.sng_tuning no longer needed
+        self.sng_difficulty_count = data.sng_difficulty_count;
+        self.sng_is_dynamic_difficulty = data.sng_is_dynamic_difficulty;
 
         let tuning_str: Vec<String> = self.sng_tuning.iter().map(|t| t.to_string()).collect();
         godot_print!(
-            "RocksmithBridge: SNG difficulty={}  start_time={:.3}s  capo={}  tuning=[{}]",
+            "RocksmithBridge: SNG difficulty={}  start_time={:.3}s  capo={}  difficulty_count={}  is_dynamic_difficulty={}  tuning=[{}]",
             self.sng_difficulty,
             self.sng_start_time,
             self.sng_capo,
+            self.sng_difficulty_count,
+            self.sng_is_dynamic_difficulty,
             tuning_str.join(", "),
         );
 

--- a/gdextension/src/rsapi.rs
+++ b/gdextension/src/rsapi.rs
@@ -3,7 +3,7 @@
 /// Uses `rocksmith2014-psarc` and `rocksmith2014-sng` Rust crates directly —
 /// no .NET runtime, no NativeAOT shim, no CLR hosting required.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 
 pub use rocksmith2014_sng::Platform;
@@ -40,6 +40,11 @@ pub struct PsarcData {
     /// Per-string tuning offsets in semitones from standard E-A-D-G-B-e tuning.
     /// An all-zero (or empty) vector means standard tuning.
     pub sng_tuning:        Vec<i16>,
+    /// Count of linked difficulty levels referenced by phrase iterations.
+    /// `> 1` means Dynamic Difficulty is present.
+    pub sng_difficulty_count: i32,
+    /// True when the arrangement uses Dynamic Difficulty progression.
+    pub sng_is_dynamic_difficulty: bool,
 }
 
 impl PsarcData {
@@ -78,7 +83,7 @@ impl PsarcData {
             })
             .cloned();
 
-        let (notes, sng_start_time, sng_difficulty, sng_capo, sng_tuning) = if let Some(ref name) = sng_name {
+        let (notes, sng_start_time, sng_difficulty, sng_capo, sng_tuning, sng_difficulty_count, sng_is_dynamic_difficulty) = if let Some(ref name) = sng_name {
             let encrypted = psarc.inflate_file(name)
                 .map_err(|e| format!("Failed to inflate SNG '{}': {}", name, e))?;
 
@@ -119,9 +124,30 @@ impl PsarcData {
             let total_phrase_iters = sng.phrase_iterations.len();
             let diff_band        = difficulty_band.min(2);   // clamp to valid band index
 
+            let (difficulty_count, is_dynamic_difficulty) = if !sng.phrase_iterations.is_empty() {
+                let mut linked_levels: HashSet<i32> = HashSet::new();
+                for pi in &sng.phrase_iterations {
+                    for &linked in &pi.difficulty {
+                        if linked >= 0 {
+                            linked_levels.insert(linked);
+                        }
+                    }
+                }
+                let count = linked_levels.len() as i32;
+                let count = if count > 0 { count } else { 1 };
+                (count, count > 1)
+            } else {
+                (1, false)
+            };
+
             eprintln!(
-                "rsapi: SNG levels={} phrase_iters={} difficulty_band={} max_difficulty_meta={}",
-                total_levels, total_phrase_iters, diff_band, max_diff
+                "rsapi: SNG levels={} phrase_iters={} difficulty_band={} max_difficulty_meta={} difficulty_count={} is_dynamic_difficulty={}",
+                total_levels,
+                total_phrase_iters,
+                diff_band,
+                max_diff,
+                difficulty_count,
+                is_dynamic_difficulty
             );
 
             // Helper closure: push one SNG note event into `entries`.
@@ -186,7 +212,15 @@ impl PsarcData {
                     "rsapi: phrase-assembly complete — {} note_events (max band_d={})",
                     entries.len(), selected_difficulty
                 );
-                (entries, start_time, selected_difficulty, capo, tuning)
+                (
+                    entries,
+                    start_time,
+                    selected_difficulty,
+                    capo,
+                    tuning,
+                    difficulty_count,
+                    is_dynamic_difficulty,
+                )
             } else {
                 // ── Fallback: flat level with most note events ───────────────────
                 // Used for malformed/non-DDC SNG files that have no phraseIterations.
@@ -202,16 +236,32 @@ impl PsarcData {
                             push_note(&mut entries, n, &sng.chords);
                         }
                         eprintln!("rsapi: fallback level {} — {} note_events", lvl.difficulty, entries.len());
-                        (entries, start_time, lvl.difficulty, capo, tuning)
+                        (
+                            entries,
+                            start_time,
+                            lvl.difficulty,
+                            capo,
+                            tuning,
+                            difficulty_count,
+                            is_dynamic_difficulty,
+                        )
                     }
                     None => {
                         eprintln!("rsapi: SNG has no levels at all");
-                        (Vec::new(), start_time, max_diff, capo, tuning)
+                        (
+                            Vec::new(),
+                            start_time,
+                            max_diff,
+                            capo,
+                            tuning,
+                            difficulty_count,
+                            is_dynamic_difficulty,
+                        )
                     }
                 }
             }
         } else {
-            (Vec::new(), 0.0f32, -1i32, 0i8, vec![])
+            (Vec::new(), 0.0f32, -1i32, 0i8, vec![], 1i32, false)
         };
 
         // ── Build WEM ID → role map from Wwise SoundBank (.bnk) files ─────────
@@ -300,7 +350,17 @@ impl PsarcData {
             None => preview_wem_bytes.clone(),  // use preview as MAIN fallback
         };
 
-        Ok(PsarcData { notes, wem_bytes, preview_wem_bytes, sng_start_time, sng_difficulty, sng_capo, sng_tuning })
+        Ok(PsarcData {
+            notes,
+            wem_bytes,
+            preview_wem_bytes,
+            sng_start_time,
+            sng_difficulty,
+            sng_capo,
+            sng_tuning,
+            sng_difficulty_count,
+            sng_is_dynamic_difficulty,
+        })
     }
 }
 


### PR DESCRIPTION
## Summary
- add simple SNG-based DD detection in `PsarcData::open` by counting unique linked phrase-iteration levels (`difficulty_count`)
- expose `is_dynamic_difficulty` (`difficulty_count > 1`) and `difficulty_count` through bridge diagnostics in `get_sng_info()`
- keep note parsing/assembly behavior unchanged while making DD vs static metadata explicit for API consumers

## Verification
- `cargo check` in `gdextension/`