### PR TITLE
Add a dedicated WorldEnviroment controller to music play scene

### DIFF
--- a/scenes/background.tscn
+++ b/scenes/background.tscn
@@ -1,16 +1,3 @@
-[gd_scene load_steps=2 format=3 uid="uid://cbkgnd00001"]
-
-; ── WorldEnvironment – black background with glow/bloom enabled ───────────────
-[sub_resource type="Environment" id="Env_black"]
-background_mode  = 1
-background_color = Color(0, 0, 0, 1)
-ambient_light_source = 0
-glow_enabled     = true
-glow_intensity   = 1.5
-glow_bloom       = 0.55
-glow_hdr_threshold = 0.4
+[gd_scene load_steps=1 format=3 uid="uid://cbkgnd00001"]
 
 [node name="Background" type="Node3D"]
-
-[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
-environment = SubResource("Env_black")

--- a/scenes/music_play.tscn
+++ b/scenes/music_play.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://cmpscene0001"]
+[gd_scene load_steps=8 format=3 uid="uid://cmpscene0001"]
 
 [ext_resource type="PackedScene" uid="uid://chighway0001" path="res://scenes/highway.tscn"     id="1_highway"]
 [ext_resource type="PackedScene" uid="uid://cbkgnd00001" path="res://scenes/background.tscn"   id="2_bg"]
@@ -6,6 +6,7 @@
 [ext_resource type="Script"                              path="res://scripts/CameraController.gd" id="4_camera"]
 [ext_resource type="PackedScene" path="res://scenes/fretboard.tscn" id="5_fretboard"]
 [ext_resource type="PackedScene" uid="uid://cchordpool01" path="res://scenes/chord_pool.tscn"  id="6_chordpool"]
+[ext_resource type="Script"                              path="res://scripts/WorldEnviromentController.gd" id="7_worldenv"]
 
 ; ── Root ──────────────────────────────────────────────────────────────────────
 [node name="MusicPlay" type="Node3D"]
@@ -17,6 +18,9 @@ transform = Transform3D(0.866025, -0.433013, 0.25, 0, 0.5, 0.866025, -0.5, -0.75
 light_color    = Color(0.9, 0.85, 1.0, 1)
 light_energy   = 1.2
 shadow_enabled = true
+
+[node name="WorldEnviroment" type="WorldEnvironment" parent="."]
+script = ExtResource("7_worldenv")
 
 ; Camera: position (12, 5.5, 10) — ChartPlayer-style: elevated on the player side,
 ; looking toward (12, 0, -7) for a natural guitar-neck perspective.

--- a/scenes/music_play.tscn
+++ b/scenes/music_play.tscn
@@ -12,13 +12,6 @@
 [node name="MusicPlay" type="Node3D"]
 script = ExtResource("3_script")
 
-; ── Directional sun-light (angled from upper-right) ──────────────────────────
-[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
-transform = Transform3D(0.866025, -0.433013, 0.25, 0, 0.5, 0.866025, -0.5, -0.75, 0.433013, 0, 8, 0)
-light_color    = Color(0.9, 0.85, 1.0, 1)
-light_energy   = 1.2
-shadow_enabled = true
-
 [node name="WorldEnviroment" type="WorldEnvironment" parent="."]
 script = ExtResource("7_worldenv")
 

--- a/scripts/WorldEnviromentController.gd
+++ b/scripts/WorldEnviromentController.gd
@@ -1,0 +1,15 @@
+extends WorldEnvironment
+class_name WorldEnviromentController
+
+
+func _ready() -> void:
+	if environment == null:
+		environment = Environment.new()
+
+	environment.background_mode = Environment.BG_COLOR
+	environment.background_color = Color(0, 0, 0, 1)
+	environment.ambient_light_source = Environment.AMBIENT_SOURCE_DISABLED
+	environment.glow_enabled = true
+	environment.glow_intensity = 1.5
+	environment.glow_bloom = 0.55
+	environment.glow_hdr_threshold = 0.4

--- a/scripts/WorldEnviromentController.gd
+++ b/scripts/WorldEnviromentController.gd
@@ -2,6 +2,9 @@ extends WorldEnvironment
 class_name WorldEnviromentController
 
 
+const SUN_LIGHT_NAME := "DirectionalLight3D"
+
+
 func _ready() -> void:
 	if environment == null:
 		environment = Environment.new()
@@ -13,3 +16,25 @@ func _ready() -> void:
 	environment.glow_intensity = 1.5
 	environment.glow_bloom = 0.55
 	environment.glow_hdr_threshold = 0.4
+
+	_ensure_directional_light()
+
+
+func _ensure_directional_light() -> void:
+	var sun := get_node_or_null(SUN_LIGHT_NAME) as DirectionalLight3D
+	if sun == null:
+		sun = DirectionalLight3D.new()
+		sun.name = SUN_LIGHT_NAME
+		add_child(sun)
+
+	sun.transform = Transform3D(
+		Basis(
+			Vector3(0.866025, -0.433013, 0.25),
+			Vector3(0.0, 0.5, 0.866025),
+			Vector3(-0.5, -0.75, 0.433013)
+		),
+		Vector3(0.0, 8.0, 0.0)
+	)
+	sun.light_color = Color(0.9, 0.85, 1.0, 1.0)
+	sun.light_energy = 1.2
+	sun.shadow_enabled = true


### PR DESCRIPTION
## Summary
- adds `scripts/WorldEnviromentController.gd` and configures environment/background and glow values from code
- adds a root `WorldEnviroment` node in `scenes/music_play.tscn` and attaches the new controller script
- removes the embedded `WorldEnvironment` node and environment subresource from `scenes/background.tscn` so environment control is centralized

## Why
This mirrors the controller extraction done for the camera so gameplay scene environment behavior is managed in one dedicated node/script rather than being hidden inside the background subscene.